### PR TITLE
Update device_info.py

### DIFF
--- a/yang/device_info.py
+++ b/yang/device_info.py
@@ -33,9 +33,9 @@ __license__ = "MIT"
 #
 sbx_n9kv_ao = {
              "address": "sbx-nxos-mgmt.cisco.com",
-             "netconf_port": 10000,
+             "netconf_port": 830,
              "restconf_port": 443,
-             "ssh_port": 818122,
+             "ssh_port": 22,
              "username": "admin",
              "password": "Admin_1234!"
           }


### PR DESCRIPTION
A user reported this issue and I have confirmed it.

On this page...

https://developer.cisco.com/learning/tracks/DC-Networking-v0/DC-Networking-TIF-v0/yang_devnet-format_part1/initial-interactions-with-the-cisco-nxos-yang-model/

...this command won't work...

python get_capabilities.py

...until we change this line....

from
 
"netconf_port": 10000,
 
to 
 
"netconf_port": 830,

....in this file

nxos-code/yang/device_info.py

Please see correct ports here: https://devnetsandbox.cisco.com/RM/Diagram/Index/dae38dd8-e8ee-4d7c-a21c-6036bed7a804?diagramType=Topology